### PR TITLE
Tox-related improvements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,15 +1,18 @@
 name: CI
 
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
   tests:
     runs-on: ubuntu-latest
     container:
-      image: themattrix/tox
+      image: python:3.10
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2.0.0
-    - name: Tests
-      run: |
+      - name: Packages
+        run: pip install tox
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Tox
+        run: |
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
           tox -v

--- a/tox.ini
+++ b/tox.ini
@@ -1,52 +1,55 @@
 [tox]
 minversion = 1.6
 skipsdist = True
-envlist = examples,pep8,autopep8,docs
+envlist = docs,examples,doc8,pep8,autopep8
 
 [testenv]
 basepython = python3
 usedevelop = True
 install_command = pip install {opts} {packages}
 
-[testenv:examples]
-description =
-  Run all python scripts from examples directory - physics check.
-# Env variable MPLBACKEND=Agg prevents display of windows during tests
-deps = -r requirements.txt
-setenv =
-  MPLBACKEND=Agg
-commands =
-  bash -ex -c 'for FILE in examples/*.py; do python $FILE; done'
-
-[testenv:pep8]
-description =
-  Style guide enforcement with flake8 and doc8.
-deps =
-  -r test-requirements.txt
-commands =
-  flake8
-  doc8
-
 [testenv:autopep8]
-description =
-  Check autopep8 suggestions.
-deps = 
-  -r test-requirements.txt
-commands =
-  python -m autopep8 --recursive --aggressive --diff --exit-code .
+description = Print autopep8 suggestions.
+envdir = {toxworkdir}/linters
+deps = -r test-requirements.txt
+commands = autopep8 --recursive --aggressive --diff --exit-code .
 
-[doc8]
-ignore = D000,D002,D004
-ignore-path = .venv,.git,.tox,gnlse.egg*,docs/_build
-
-[flake8]
-exclude = .venv,.git,.tox,docs,*egg,build
+[testenv:doc8]
+description = Style guide enforcement with doc8.
+envdir = {toxworkdir}/linters
+deps = -r test-requirements.txt
+commands = doc8 {posargs}
 
 [testenv:docs]
-description =
-  Build main documentation: html and pdf file.
-deps =
-  -r docs/requirements.txt
+description = Build project documentation.
+envdir = {toxworkdir}/sphinx
+deps = -r docs/requirements.txt
+allowlist_externals = rm
 commands =
   rm -rf docs/_build
   sphinx-build -W -b html docs docs/_build
+
+[testenv:examples]
+description = Run all python scripts from examples directory - physics check.
+envdir = {toxworkdir}/build
+deps = -r requirements.txt
+# Env variable MPLBACKEND=Agg prevents display of windows during tests
+setenv = MPLBACKEND=Agg
+allowlist_externals = bash
+commands = bash -ex -c 'for FILE in examples/*.py; do python $FILE; done'
+
+[testenv:pep8]
+description = Style guide enforcement with flake8.
+envdir = {toxworkdir}/linters
+deps = -r test-requirements.txt
+commands = flake8 {posargs}
+
+[doc8]
+# D000 - invalid rst format
+# D002 - no trailing whitespace
+# D004 - no carriage returns (use unix newlines)
+ignore = D000,D002,D004
+ignore-path = .git,.tox,.venv,docs/_build,*.egg-info
+
+[flake8]
+exclude = .git,.tox,.venv,build,docs,*.egg-info


### PR DESCRIPTION
This commit introduces a bunch of changes to improve the tests execution with `tox` tool, involving both cosmetic/syntax-sugar changes and more serious ones.

First, the GitHub actions were changed to be triggered now also for every push, so people can verify tests even before opening a pull request.

Second, te container image used within the GitHub Actions job were changed to recent Python, as the previously used container was not updated for 3 years and now it causes CI failures due to recent flake8 (6.0.0) requiring Python >= 3.8.1. Related change in job's steps (packages installation) was also added.

Third, the tox configuration file was reshaped the following way:
– the testenvs definitions were placed in alphabetical order in file
– the missing allowlist_externals were added where required (as missing that would cause errors in future releases of tox)
– introduced dedicated testenv for doc8 command
– introduced envdir key for testenvs that share the same dependencies (avoiding downloading the same packages multiple times, faster run)
– added comment to doc8 configuration section regarding ignored codes
– written excluded paths for doc8 and flake8 in alphabetical order