### PR TITLE
Minor fixes for docs configuration

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,12 +14,19 @@ master_doc = 'index'
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
-	'numpydoc'
+    'numpydoc',
 ]
 
 autodoc_mock_imports = [
-    'numpy', 'matplotlib', 'matplotlib.pyplot', 'scipy', 'scipy.integrate',
-    'scipy.interpolate', 'pyfftw', 'hdf5storage', 'tqdm'
+    'hdf5storage',
+    'matplotlib',
+    'matplotlib.pyplot',
+    'numpy',
+    'pyfftw',
+    'scipy',
+    'scipy.integrate',
+    'scipy.interpolate',
+    'tqdm',
 ]
 
 autosummary_generate = True

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 numpydoc
 sphinx_rtd_theme
 rinohtype
-pygments==2.5.1
+pygments>=2.5.1


### PR DESCRIPTION
The docs/conf.py is excluded from pep8 checks, so the tab character included there was not noticed. Also I propose to use latest pygments as for all other requirements there is no upper version of constrains specified (this should be done probably per release).